### PR TITLE
Retornar se Thread está Alive/Interrupted

### DIFF
--- a/src/main/java/com/victorlaerte/asynctask/AsyncTask.java
+++ b/src/main/java/com/victorlaerte/asynctask/AsyncTask.java
@@ -72,4 +72,14 @@ public abstract class AsyncTask {
 
 		this.backGroundThread.interrupt();
 	}
+	
+	public final boolean isInterrupted() {
+
+		return this.backGroundThread.isInterrupted();
+	}
+
+	public final boolean isAlive() {
+
+		return this.backGroundThread.isAlive();
+	}
 }


### PR DESCRIPTION
Permite retornar o status da Thread.

Uma opção agradável seria tornar a propriedade backGroundThread "protected", assim suas heranças poderiam acessar seus states também, porém acreditamos aqui ser melhor manter usando proxies.